### PR TITLE
Update plugin.py to make configure function avaliable on Windows platform

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -58,10 +58,10 @@ def check_output(shell_cmd, env=None, cwd=None):
         shell=shell,
         cwd=cwd)
     outs, errs = proc.communicate()
-    errs = errs.decode("utf-8")
+    errs = errs.decode("ISO-8859-1")
     if errs:
         raise CheckOutputException(errs)
-    return outs.decode("utf-8")
+    return outs.decode("ISO-8859-1")
 
 
 def get_vcvarsall_path(desired_vs_major_version: int) -> str:


### PR DESCRIPTION
The current CMakeBuilder can't working properly on Windows. Through the debug window I found that the UTF-8 decode ruin the configure function. So I change it to the ISO-8859-1 and it works on Windows(Linux not tested).